### PR TITLE
Drupal9 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@ Commerce Fee submodule
 Note: a modification is necessary in commerce file: commerce/src/Plugin/Field/FieldType/PluginItemDeriver.php
   * Modify method getDerivativeDefinitions()
   * add commerce_fee plugin to the $plugin_types array: 'commerce_fee' => $this->t('Commerce fee'),
+
+OR
+
+Get latest working patch from [here](https://www.drupal.org/project/commerce/issues/2903716) and add it to your `composer.json` similar to this and run composer install to patch commerce.
+
+    "extra": {
+        "enable-patching": true,
+        "patches": {
+          ...
+            "drupal/commerce": {
+                "Implement the ability to add fees to an order dgo.to/2903716": "https://www.drupal.org/files/issues/2020-11-18/add-plugin-type-2903716-72.patch"
+            },
+          ...

--- a/src/Plugin/Commerce/Fee/FeeInterface.php
+++ b/src/Plugin/Commerce/Fee/FeeInterface.php
@@ -3,7 +3,7 @@
 namespace Drupal\commerce_fee\Plugin\Commerce\Fee;
 
 use Drupal\commerce_fee\Entity\FeeInterface as FeeEntityInterface;
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
@@ -17,7 +17,7 @@ use Drupal\Core\Plugin\PluginFormInterface;
  * @see \Drupal\commerce_fee\Plugin\Commerce\Fee\OrderFeeInterface
  * @see \Drupal\commerce_fee\Plugin\Commerce\Fee\OrderItemFeeInterface
  */
-interface FeeInterface extends ConfigurablePluginInterface, PluginFormInterface, PluginInspectionInterface {
+interface FeeInterface extends ConfigurableInterface, PluginFormInterface, PluginInspectionInterface {
 
   /**
    * Gets the fee entity type ID.


### PR DESCRIPTION
Have tried to use on Drupal 9 installation and had the following problem appear 

Have also updated readme with instructions for composer.json based patch (which might came in handy)
```
Error: Interface 'Drupal\Component\Plugin\ConfigurablePluginInterface' not found in include() (line 20 of /app/modules/custom/commerce_fee/src/Plugin/Commerce/Fee/FeeInterface.php)
#0 /app/vendor/composer/ClassLoader.php(480): include()
#1 /app/vendor/composer/ClassLoader.php(346): Composer\Autoload\includeFile('/app/modules/cu...')
#2 [internal function]: Composer\Autoload\ClassLoader->loadClass('Drupal\\commerce...')
#3 /app/modules/custom/commerce_fee/src/Plugin/Commerce/Fee/FeeBase.php(16): spl_autoload_call('Drupal\\commerce...')
#4 /app/vendor/composer/ClassLoader.php(480): include('/app/modules/cu...')
#5 /app/vendor/composer/ClassLoader.php(346): Composer\Autoload\includeFile('/app/modules/cu...')
#6 [internal function]: Composer\Autoload\ClassLoader->loadClass('Drupal\\commerce...')
#7 /app/modules/custom/commerce_fee/src/Plugin/Commerce/Fee/OrderItemFeeBase.php(11): spl_autoload_call('Drupal\\commerce...')
#8 /app/vendor/composer/ClassLoader.php(480): include('/app/modules/cu...')
#9 /app/vendor/composer/ClassLoader.php(346): Composer\Autoload\includeFile('/app/modules/cu...')
#10 [internal function]: Composer\Autoload\ClassLoader->loadClass('Drupal\\commerce...')
#11 /app/modules/custom/commerce_fee/src/Plugin/Commerce/Fee/OrderItemFixedAmount.php(18): spl_autoload_call('Drupal\\commerce...')
#12 /app/vendor/composer/ClassLoader.php(480): include('/app/modules/cu...')
#13 /app/vendor/composer/ClassLoader.php(346): Composer\Autoload\includeFile('/app/modules/cu...')
#14 [internal function]: Composer\Autoload\ClassLoader->loadClass('Drupal\\commerce...')
#15 [internal function]: spl_autoload_call('Drupal\\commerce...')
#16 /app/modules/contrib/commerce/src/Plugin/Field/FieldWidget/PluginSelectWidget.php(167): is_subclass_of('Drupal\\commerce...', 'Drupal\\Core\\Plu...')
#17 /app/modules/contrib/commerce/src/Plugin/Field/FieldWidget/PluginSelectWidget.php(128): Drupal\commerce\Plugin\Field\FieldWidget\PluginSelectWidget::supportsConfiguration(Array)
#18 /app/modules/contrib/commerce/src/Plugin/Field/FieldWidget/PluginRadiosWidget.php(26): Drupal\commerce\Plugin\Field\FieldWidget\PluginSelectWidget->formElement(Object(Drupal\Core\Field\FieldItemList), 0, Array, Array, Object(Drupal\Core\Form\FormState))
#19 /app/core/lib/Drupal/Core/Field/WidgetBase.php(342): Drupal\commerce\Plugin\Field\FieldWidget\PluginRadiosWidget->formElement(Object(Drupal\Core\Field\FieldItemList), 0, Array, Array, Object(Drupal\Core\Form\FormState))
#20 /app/core/lib/Drupal/Core/Field/WidgetBase.php(209): Drupal\Core\Field\WidgetBase->formSingleElement(Object(Drupal\Core\Field\FieldItemList), 0, Array, Array, Object(Drupal\Core\Form\FormState))
#21 /app/core/lib/Drupal/Core/Field/WidgetBase.php(111): Drupal\Core\Field\WidgetBase->formMultipleElements(Object(Drupal\Core\Field\FieldItemList), Array, Object(Drupal\Core\Form\FormState))
#22 /app/core/lib/Drupal/Core/Entity/Entity/EntityFormDisplay.php(178): Drupal\Core\Field\WidgetBase->form(Object(Drupal\Core\Field\FieldItemList), Array, Object(Drupal\Core\Form\FormState))
#23 /app/core/lib/Drupal/Core/Entity/ContentEntityForm.php(121): Drupal\Core\Entity\Entity\EntityFormDisplay->buildForm(Object(Drupal\commerce_fee\Entity\Fee), Array, Object(Drupal\Core\Form\FormState))
#24 /app/modules/custom/commerce_fee/src/Form/FeeForm.php(38): Drupal\Core\Entity\ContentEntityForm->form(Array, Object(Drupal\Core\Form\FormState))
#25 /app/core/lib/Drupal/Core/Entity/EntityForm.php(106): Drupal\commerce_fee\Form\FeeForm->form(Array, Object(Drupal\Core\Form\FormState))
#26 /app/modules/custom/commerce_fee/src/Form/FeeForm.php(31): Drupal\Core\Entity\EntityForm->buildForm(Array, Object(Drupal\Core\Form\FormState))
#27 [internal function]: Drupal\commerce_fee\Form\FeeForm->buildForm(Array, Object(Drupal\Core\Form\FormState))
#28 /app/core/lib/Drupal/Core/Form/FormBuilder.php(532): call_user_func_array(Array, Array)
#29 /app/core/lib/Drupal/Core/Form/FormBuilder.php(278): Drupal\Core\Form\FormBuilder->retrieveForm('commerce_fee_ad...', Object(Drupal\Core\Form\FormState))
#30 /app/core/lib/Drupal/Core/Controller/FormController.php(73): Drupal\Core\Form\FormBuilder->buildForm(Object(Drupal\commerce_fee\Form\FeeForm), Object(Drupal\Core\Form\FormState))
#31 [internal function]: Drupal\Core\Controller\FormController->getContentResult(Object(Symfony\Component\HttpFoundation\Request), Object(Drupal\Core\Routing\RouteMatch))
#32 /app/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)
#33 /app/core/lib/Drupal/Core/Render/Renderer.php(573): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#34 /app/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#35 /app/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array)
#36 /app/vendor/symfony/http-kernel/HttpKernel.php(158): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#37 /app/vendor/symfony/http-kernel/HttpKernel.php(80): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#38 /app/core/lib/Drupal/Core/StackMiddleware/Session.php(57): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#39 /app/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(47): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#40 /app/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#41 /app/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#42 /app/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(47): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#43 /app/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(52): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#44 /app/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#45 /app/core/lib/Drupal/Core/DrupalKernel.php(706): Stack\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#46 /app/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#47 {main}
```

